### PR TITLE
Add minimal dividend viewer web app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+cache/*.json
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # Zingo2
+
+Simple Flask app to view dividend history.
+
+## Usage
+
+```
+python run.py
+```
+
+Open http://localhost:5000, paste tickers separated by commas or spaces, and load the chart and table.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+flask
+yfinance
+pandas

--- a/run.py
+++ b/run.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pandas as pd
+import yfinance as yf
+from flask import Flask, jsonify, render_template, request
+
+app = Flask(__name__)
+
+CACHE_DIR = Path("cache")
+CACHE_DIR.mkdir(exist_ok=True)
+CACHE_TTL = timedelta(hours=24)
+_memory_cache: dict[str, tuple[datetime, list[dict]]] = {}
+
+
+def fetch_dividends(ticker: str) -> list[dict]:
+    ticker = ticker.upper()
+    now = datetime.utcnow()
+    # in-memory cache
+    if ticker in _memory_cache:
+        ts, data = _memory_cache[ticker]
+        if now - ts < CACHE_TTL:
+            return data
+    path = CACHE_DIR / f"{ticker}.json"
+    if path.exists():
+        with open(path) as f:
+            obj = json.load(f)
+        ts = datetime.fromisoformat(obj["timestamp"])
+        if now - ts < CACHE_TTL:
+            data = obj["data"]
+            _memory_cache[ticker] = (ts, data)
+            return data
+    series = yf.Ticker(ticker).dividends
+    one_year_ago = now - timedelta(days=365)
+    recent = series[series.index >= one_year_ago]
+    data = [
+        {"date": d.strftime("%Y-%m-%d"), "amount": float(v)}
+        for d, v in recent.items()
+    ]
+    obj = {"timestamp": now.isoformat(), "data": data}
+    with open(path, "w") as f:
+        json.dump(obj, f)
+    _memory_cache[ticker] = (now, data)
+    return data
+
+
+def detect_change(data: list[dict]) -> dict:
+    if not data:
+        return {"status": "suspension", "last": None, "previous": None, "date": None}
+    last = data[-1]
+    if len(data) == 1:
+        return {
+            "status": "no_change",
+            "last": last["amount"],
+            "previous": None,
+            "date": last["date"],
+        }
+    prev = data[-2]
+    status = "no_change"
+    if last["amount"] > prev["amount"]:
+        status = "increase"
+    elif last["amount"] < prev["amount"]:
+        status = "cut"
+    return {
+        "status": status,
+        "last": last["amount"],
+        "previous": prev["amount"],
+        "date": last["date"],
+    }
+
+
+@app.route("/")
+def index():
+    return render_template("index.html")
+
+
+@app.route("/dividends", methods=["POST"])
+def dividends():
+    tickers_raw = request.json.get("tickers", "")
+    tickers = [t.strip().upper() for t in re.split(r"[\s,]+", tickers_raw) if t.strip()]
+    result = {"series": [], "changes": []}
+    for t in tickers:
+        data = fetch_dividends(t)
+        result["series"].append({"ticker": t, "data": data})
+        change = detect_change(data)
+        change["ticker"] = t
+        result["changes"].append(change)
+    return jsonify(result)
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Dividend Viewer</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns"></script>
+    <style>
+        body { font-family: sans-serif; margin: 2rem; }
+        textarea { width: 300px; height: 100px; }
+        table { border-collapse: collapse; margin-top: 2rem; }
+        th, td { border: 1px solid #ccc; padding: 4px 8px; }
+        th { cursor: pointer; }
+        .increase { background: #d4edda; }
+        .cut { background: #f8d7da; }
+        .suspension { background: #e2e3e5; }
+    </style>
+</head>
+<body>
+<h1>Dividend Viewer</h1>
+<textarea id="tickers" placeholder="Enter tickers separated by space or comma"></textarea>
+<br>
+<button id="load">Load</button>
+<canvas id="chart" width="800" height="400"></canvas>
+<table id="summary">
+    <thead>
+    <tr>
+        <th data-key="ticker">Ticker</th>
+        <th data-key="date">Last Date</th>
+        <th data-key="last">Last Dividend</th>
+        <th data-key="previous">Previous Dividend</th>
+        <th data-key="status">Status</th>
+    </tr>
+    </thead>
+    <tbody></tbody>
+</table>
+<script>
+const ctx = document.getElementById('chart').getContext('2d');
+let chart;
+
+function renderChart(series) {
+    const datasets = series.map(s => ({
+        label: s.ticker,
+        data: s.data.map(p => ({x: p.date, y: p.amount})),
+        fill: false
+    }));
+    if (chart) chart.destroy();
+    chart = new Chart(ctx, {
+        type: 'line',
+        data: { datasets },
+        options: {
+            parsing: false,
+            scales: { x: { type: 'time', time: { unit: 'month' } } }
+        }
+    });
+}
+
+function renderTable(changes) {
+    const tbody = document.querySelector('#summary tbody');
+    tbody.innerHTML = '';
+    changes.forEach(c => {
+        const tr = document.createElement('tr');
+        tr.className = c.status;
+        tr.innerHTML = `
+            <td>${c.ticker}</td>
+            <td>${c.date || ''}</td>
+            <td>${c.last ?? ''}</td>
+            <td>${c.previous ?? ''}</td>
+            <td>${c.status}</td>`;
+        tbody.appendChild(tr);
+    });
+}
+
+function sortTable(key) {
+    const rows = Array.from(document.querySelector('#summary tbody').children);
+    const asc = sortTable.asc = sortTable.asc === key ? !sortTable.asc : true;
+    rows.sort((a,b) => {
+        const va = a.children[Array.from(a.parentNode.parentNode.children[0].children).findIndex(th=>th.dataset.key==key)].innerText;
+        const vb = b.children[Array.from(b.parentNode.parentNode.children[0].children).findIndex(th=>th.dataset.key==key)].innerText;
+        return asc ? va.localeCompare(vb, undefined, {numeric:true}) : vb.localeCompare(va, undefined, {numeric:true});
+    });
+    const tbody = document.querySelector('#summary tbody');
+    rows.forEach(r => tbody.appendChild(r));
+}
+
+document.getElementById('load').addEventListener('click', () => {
+    fetch('/dividends', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tickers: document.getElementById('tickers').value })
+    }).then(r => r.json()).then(data => {
+        renderChart(data.series);
+        renderTable(data.changes);
+    });
+});
+
+document.querySelectorAll('#summary th').forEach(th => {
+    th.addEventListener('click', () => sortTable(th.dataset.key));
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build `run.py` Flask server that fetches dividend history with 24h JSON cache
- add frontend using Chart.js and sortable table for recent dividend changes
- document usage and dependencies

## Testing
- `pip install flask yfinance pandas`
- `python run.py` *(fails: connections require manual termination or network restrictions may block external requests)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b9725e68832ca435d9f7836f5d18